### PR TITLE
feat(deps): update langchain4j to 1.7.1

### DIFF
--- a/bonita-connector-ai-core/pom.xml
+++ b/bonita-connector-ai-core/pom.xml
@@ -17,12 +17,10 @@
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j</artifactId>
-      <version>${langchain4j.version}</version>
     </dependency>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-document-parser-apache-tika</artifactId>
-      <version>${langchain4j.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/AbstractAiChat.java
+++ b/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/AbstractAiChat.java
@@ -19,11 +19,11 @@ package org.bonitasoft.connectors.ai;
 import dev.langchain4j.data.document.DocumentLoader;
 import dev.langchain4j.data.document.parser.apache.tika.ApacheTikaDocumentParser;
 import dev.langchain4j.data.message.*;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import java.util.Base64;
 import org.bonitasoft.connectors.ai.langchain4j.UserDocumentSource;
 
-public abstract class AbstractAiChat<T extends ChatLanguageModel> implements AiChat<T> {
+public abstract class AbstractAiChat<T extends ChatModel> implements AiChat<T> {
 
     protected ChatMessage newDocMessage(UserDocument document) {
         return UserMessage.from(

--- a/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/AiChat.java
+++ b/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/AiChat.java
@@ -16,9 +16,9 @@
  */
 package org.bonitasoft.connectors.ai;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 
-public interface AiChat<T extends ChatLanguageModel> {
+public interface AiChat<T extends ChatModel> {
 
     AiConfiguration getConfiguration();
 

--- a/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/ask/AskAiChat.java
+++ b/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/ask/AskAiChat.java
@@ -17,7 +17,7 @@
 package org.bonitasoft.connectors.ai.ask;
 
 import dev.langchain4j.data.message.*;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import java.util.ArrayList;
@@ -29,7 +29,7 @@ import org.bonitasoft.connectors.ai.UserDocument;
 import org.bonitasoft.connectors.utils.AiResponse;
 
 @Slf4j
-public abstract class AskAiChat<T extends ChatLanguageModel> extends AbstractAiChat<T> implements AiChat<T>, AskChat {
+public abstract class AskAiChat<T extends ChatModel> extends AbstractAiChat<T> implements AiChat<T>, AskChat {
 
     protected final AiConfiguration configuration;
 

--- a/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/classify/ClassifyAiChat.java
+++ b/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/classify/ClassifyAiChat.java
@@ -17,7 +17,7 @@
 package org.bonitasoft.connectors.ai.classify;
 
 import dev.langchain4j.data.message.*;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.input.Prompt;
@@ -34,8 +34,7 @@ import org.bonitasoft.connectors.utils.AiResponse;
 import org.bonitasoft.connectors.utils.IOs;
 
 @Slf4j
-public abstract class ClassifyAiChat<T extends ChatLanguageModel> extends AbstractAiChat<T>
-        implements AiChat<T>, ClassifyChat {
+public abstract class ClassifyAiChat<T extends ChatModel> extends AbstractAiChat<T> implements AiChat<T>, ClassifyChat {
 
     protected String systemPrompt;
     protected String userPrompt;

--- a/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/extract/ExtractAiChat.java
+++ b/bonita-connector-ai-core/src/main/java/org/bonitasoft/connectors/ai/extract/ExtractAiChat.java
@@ -19,7 +19,7 @@ package org.bonitasoft.connectors.ai.extract;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.input.Prompt;
@@ -34,8 +34,7 @@ import org.bonitasoft.connectors.ai.UserDocument;
 import org.bonitasoft.connectors.utils.AiResponse;
 import org.bonitasoft.connectors.utils.IOs;
 
-public abstract class ExtractAiChat<T extends ChatLanguageModel> extends AbstractAiChat<T>
-        implements AiChat<T>, ExtractChat {
+public abstract class ExtractAiChat<T extends ChatModel> extends AbstractAiChat<T> implements AiChat<T>, ExtractChat {
 
     protected final String systemPrompt;
     protected final String userPrompt;

--- a/bonita-connector-ai-mistral/pom.xml
+++ b/bonita-connector-ai-mistral/pom.xml
@@ -40,7 +40,6 @@
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-mistral-ai</artifactId>
-      <version>${langchain4j.version}</version>
     </dependency>
     <!-- Test -->
     <dependency>

--- a/bonita-connector-ai-openai/pom.xml
+++ b/bonita-connector-ai-openai/pom.xml
@@ -40,7 +40,6 @@
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-open-ai</artifactId>
-      <version>${langchain4j.version}</version>
     </dependency>
     <!-- Test -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <!-- Bonita -->
     <bonita-runtime.version>10.2.0</bonita-runtime.version>
     <!-- AI -->
-    <langchain4j.version>1.0.0-beta3</langchain4j.version>
+    <langchain4j.version>1.7.1</langchain4j.version>
     <!-- Tests -->
     <junit-jupiter-engine.version>5.12.2</junit-jupiter-engine.version>
     <assertj-core.version>3.27.3</assertj-core.version>
@@ -96,6 +96,13 @@
         <groupId>org.bonitasoft.runtime</groupId>
         <artifactId>bonita-runtime-bom</artifactId>
         <version>${bonita-runtime.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-bom</artifactId>
+        <version>${langchain4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Summary
  - Updated langchain4j dependencies from 1.0.0-beta3 to 1.7.1
  - Added langchain4j-bom to dependency management for centralized version control
  - Removed explicit version declarations from child modules (now managed by BOM)
  - Updated deprecated ChatLanguageModel interface to ChatModel across all AI chat implementations

  ## Changes
  - **pom.xml**: Updated langchain4j.version property and added langchain4j-bom to dependencyManagement
  - **Child POMs**: Removed explicit version tags (versions now inherited from BOM)
  - **Core classes**: Migrated from deprecated ChatLanguageModel to ChatModel interface

  ## Test plan
  - [x] All existing tests pass
  - [x] No breaking changes to connector functionality
  - [x] Code compiles successfully with new langchain4j version

  🤖 Generated with [Claude Code](https://claude.com/claude-code)